### PR TITLE
ci: add publish release action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,40 @@
+name: Build & publish release
+
+on:
+  workflow_dispatch:
+  release:
+    types: [created]
+  push:
+    tags:
+      - "v*"
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      repository-projects: write
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: "temurin"
+          server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+          settings-path: ${{ github.workspace }} # location for the settings.xml file
+
+      - name: Build with Maven
+        run: mvn -B package --file pom.xml
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          prerelease: false
+          draft: false
+          files: target/TheGoldEconomy-*.jar
+          generate_release_notes: true

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ConfusedAlex</groupId>
     <artifactId>TheGoldEconomy</artifactId>
-    <version>1.0</version>
+    <version>1.6.3</version>
     <packaging>jar</packaging>
 
     <name>TheGoldEconomy</name>


### PR DESCRIPTION
I added an action that publishes a release by pushing a tag (vX.X.X) or creating a new release.
Also update plugin version at `pom.xml`
